### PR TITLE
Enable greater zoom range

### DIFF
--- a/src/js/TrackballControls.js
+++ b/src/js/TrackballControls.js
@@ -177,7 +177,10 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 			if ( factor !== 1.0 && factor > 0.0 ) {
 
-				_eye.multiplyScalar( factor );
+				this.object.fov *= factor;
+				if ( this.object.fov < this.object.minFov ) { this.object.fov = this.object.minFov; }
+				if ( this.object.fov > this.object.maxFov ) { this.object.fov = this.object.maxFov; }
+				this.object.updateProjectionMatrix();
 
 				if ( _this.staticMoving ) {
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -152,6 +152,8 @@
 	);
 	camera.position.z = 1.5;
 	camera.position.y = 0.2;
+	camera.minFov = 5;
+	camera.maxFov = cameraDepth;
 
 	var renderer = new THREE.WebGLRenderer();
 	renderer.setSize(width, height);


### PR DESCRIPTION
Hello! As discussed over email, here is a PR that reimplements zoom in terms of modifying the FOV, rather than moving the camera closer to the globe.

This is motivated by a request from David Rumsey to increase the max zoom. When I first went to implement this, the camera would penetrate the surface of the globe! This PR therefore changes the zoom implementation to enable a greater max zoom.

What do you think?